### PR TITLE
Fixed out of bounds exception

### DIFF
--- a/app/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashSRDChunkSource.java
+++ b/app/src/main/java/com/google/android/exoplayer2/source/dash/DefaultDashSRDChunkSource.java
@@ -51,6 +51,8 @@ import com.google.android.exoplayer2.util.Util;
 import java.io.IOException;
 import java.util.List;
 
+import fr.unice.i3s.uca4svr.toucan_vr.dashSRD.track_selection.PyramidalTrackSelection;
+
 /**
  * A default {@link DashChunkSource} implementation.
  */
@@ -182,8 +184,15 @@ public class DefaultDashSRDChunkSource implements DashChunkSource {
 
         long bufferedDurationUs = previous != null ? (previous.endTimeUs - playbackPositionUs) : 0;
 
-        //Call the method to choose the track
-        int a = adaptationSetIndex;
+        // Provide the info needed to perform the pyramidal strategy
+        if (trackSelection instanceof PyramidalTrackSelection) {
+            PyramidalTrackSelection pyramidalTrackSelection = (PyramidalTrackSelection)trackSelection;
+            pyramidalTrackSelection.updateAdaptationSetIndex(adaptationSetIndex);
+            pyramidalTrackSelection.updatePlaybackPosition(playbackPositionUs);
+            pyramidalTrackSelection.updateNextChunkPosition(previous != null ? previous.endTimeUs : 0);
+        }
+
+        // Call the method to update the quality for the next chunk
         trackSelection.updateSelectedTrack(bufferedDurationUs);
 
         RepresentationHolder representationHolder =

--- a/app/src/main/java/fr/unice/i3s/uca4svr/toucan_vr/tilespicker/TilesPicker.java
+++ b/app/src/main/java/fr/unice/i3s/uca4svr/toucan_vr/tilespicker/TilesPicker.java
@@ -18,23 +18,18 @@ public class TilesPicker implements IPickEvents {
     }
 
     public synchronized boolean isPicked(int index) {
-        if(pickedTiles!=null)
+        if(pickedTiles!=null && pickedTiles.length > index)
             return pickedTiles[index];
         else
             return true;
     }
 
-
-
     @Override
     public synchronized void onPick(GVRPicker picker) {
         GVRPicker.GVRPickedObject[] pickedObjects = picker.getPicked();
         pickedTiles = new boolean[pickedObjects.length];
-        if(pickedObjects!=null) {
-            for (int i=0; i<pickedObjects.length; i++) {
-                pickedTiles[i] = pickedObjects[i]==null ? false : true;
-            }
-        }
+        for (int i=0; i<pickedObjects.length; i++)
+            pickedTiles[i] = pickedObjects[i] != null;
     }
 
     @Override


### PR DESCRIPTION
Hello guys. The wifi was not working on my computer for some reason, so I decided to spend some time addressing this bug instead ;)

Since we introduced the possibility of re-launching the applications with different intents, we had this "index out of bounds" exception due to a static counter that wasn't resetted in between launches.
I removed the static variable altogheter. Now the adaptationSetIndex is passed directly from DashChunkSource to the PyramidalTrackSelection, so we don't need the counter anymore.

I also pass the playback position and the chunk position to the pyramidal track selection, since we will need these info when we work on the dynamic editing.

Besides this, I removed a couple of warnings and made some minor changes.

It's not a lot of code to review. Perhaps @savinoda can take a look at it since he worked on this originally.

Thanks!