### PR TITLE
Modified bandwidth and freeze events logging

### DIFF
--- a/app/src/main/java/fr/unice/i3s/uca4svr/toucan_vr/tracking/BandwidthConsumedTracker.java
+++ b/app/src/main/java/fr/unice/i3s/uca4svr/toucan_vr/tracking/BandwidthConsumedTracker.java
@@ -43,81 +43,89 @@ import ch.qos.logback.core.FileAppender;
  */
 public class BandwidthConsumedTracker implements TransferListener<Object> {
 
-    // Each logger must have a different ID,
-    // so that creating a new logger won't override the previous one
-    private static int loggerNextID = 0;
+  // Each logger must have a different ID,
+  // so that creating a new logger won't override the previous one
+  private static int loggerNextID = 0;
 
-    private final Logger logger;
+  private final Logger logger;
 
-    private long totalBytesConsumed = 0;
-    private boolean firstTransfer = true;
-    private final Clock clock;
+  private long totalBytesConsumed = 0;
+  private boolean firstTransfer = true;
+  private final Clock clock;
+  private long lastRecordTime;
 
-    /**
-     * Initialize a {@link BandwidthConsumedTracker}, that will record the consumed
-     * bandwidth during playback to a file name logFilePrefix_date.csv.
-     * Be aware that tracking is done by calling the <code>track</code> method every time
-     * and entry is needed.
-     *
-     * @param logFilePrefix The prefix for the log file name
-     */
-    public BandwidthConsumedTracker(String logFilePrefix) {
 
-        clock = new SystemClock();
+  /**
+   * Initialize a {@link BandwidthConsumedTracker}, that will record the consumed
+   * bandwidth during playback to a file name logFilePrefix_date.csv.
+   * Be aware that tracking is done by calling the <code>track</code> method every time
+   * and entry is needed.
+   *
+   * @param logFilePrefix The prefix for the log file name
+   */
+  public BandwidthConsumedTracker(String logFilePrefix) {
 
-        String logFilePath = Environment.getExternalStoragePublicDirectory("toucan/logs/")
-                + File.separator
-                + createLogFileName(logFilePrefix);
+    clock = new SystemClock();
+    lastRecordTime = -1000;
 
-        // Initialize and configure a new logger in logback
-        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        PatternLayoutEncoder encoder1 = new PatternLayoutEncoder();
-        encoder1.setContext(lc);
-        encoder1.setPattern("%msg%n");
-        encoder1.start();
+    String logFilePath = Environment.getExternalStoragePublicDirectory("toucan/logs/")
+            + File.separator
+            + createLogFileName(logFilePrefix);
 
-        FileAppender<ILoggingEvent> fileAppender = new FileAppender<>();
-        fileAppender.setContext(lc);
-        fileAppender.setFile(logFilePath);
-        fileAppender.setEncoder(encoder1);
-        fileAppender.start();
+    // Initialize and configure a new logger in logback
+    LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+    PatternLayoutEncoder encoder1 = new PatternLayoutEncoder();
+    encoder1.setContext(lc);
+    encoder1.setPattern("%msg%n");
+    encoder1.start();
 
-        // getting the instanceof the logger
-        logger = LoggerFactory.getLogger("fr.unice.i3s.uca4svr.tracking.BandwidthConsumedTracker"
-                + loggerNextID++);
-        // I know the logger is from logback, this is the implementation i'm using below slf4j API.
-        ((ch.qos.logback.classic.Logger) logger).addAppender(fileAppender);
+    FileAppender<ILoggingEvent> fileAppender = new FileAppender<>();
+    fileAppender.setContext(lc);
+    fileAppender.setFile(logFilePath);
+    fileAppender.setEncoder(encoder1);
+    fileAppender.start();
+
+    // getting the instanceof the logger
+    logger = LoggerFactory.getLogger("fr.unice.i3s.uca4svr.tracking.BandwidthConsumedTracker"
+            + loggerNextID++);
+    // I know the logger is from logback, this is the implementation i'm using below slf4j API.
+    ((ch.qos.logback.classic.Logger) logger).addAppender(fileAppender);
+  }
+
+  /**
+   * Builds the name of the logfile by appending the date to the logFilePrefix
+   *
+   * @param logFilePrefix the prefix for the log file
+   * @return the name of the log file
+   */
+  private String createLogFileName(String logFilePrefix) {
+    DateFormat dateFormat = new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss", Locale.US);
+    Date date = new Date();
+    return String.format("%s_bandwidth_%s.csv", logFilePrefix, dateFormat.format(date));
+  }
+
+  @Override
+  public void onTransferStart(Object source, DataSpec dataSpec) {
+    if (firstTransfer) {
+      logger.error(String.format(Locale.ENGLISH, "%d, %d",
+              clock.elapsedRealtime(), totalBytesConsumed));
+      firstTransfer = false;
     }
+  }
 
-    /**
-     * Builds the name of the logfile by appending the date to the logFilePrefix
-     * @param logFilePrefix the prefix for the log file
-     * @return the name of the log file
-     */
-    private String createLogFileName(String logFilePrefix) {
-        DateFormat dateFormat = new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss", Locale.US);
-        Date date = new Date();
-        return String.format("%s_bandwidth_%s.csv", logFilePrefix, dateFormat.format(date));
+  @Override
+  public void onBytesTransferred(Object source, int bytesTransferred) {
+    totalBytesConsumed += bytesTransferred;
+    long currentTime = clock.elapsedRealtime();
+    if (currentTime - lastRecordTime > 16) {
+      lastRecordTime = currentTime;
+      logger.error(String.format(Locale.ENGLISH, "%d, %d",
+              currentTime, totalBytesConsumed));
     }
+  }
 
-    @Override
-    public void onTransferStart(Object source, DataSpec dataSpec) {
-        if (firstTransfer) {
-            logger.error(String.format(Locale.ENGLISH, "%d, %d",
-                    clock.elapsedRealtime(), totalBytesConsumed));
-            firstTransfer = false;
-        }
-    }
+  @Override
+  public void onTransferEnd(Object source) {
 
-    @Override
-    public void onBytesTransferred(Object source, int bytesTransferred) {
-        totalBytesConsumed += bytesTransferred;
-        logger.error(String.format(Locale.ENGLISH, "%d, %d",
-                clock.elapsedRealtime(), totalBytesConsumed));
-    }
-
-    @Override
-    public void onTransferEnd(Object source) {
-
-    }
+  }
 }

--- a/app/src/main/java/fr/unice/i3s/uca4svr/toucan_vr/tracking/FreezingEventsTracker.java
+++ b/app/src/main/java/fr/unice/i3s/uca4svr/toucan_vr/tracking/FreezingEventsTracker.java
@@ -107,8 +107,8 @@ public class FreezingEventsTracker {
             wasBuffering = false;
             long freezeDuration = clock.elapsedRealtime() - freezeStartTime;
             logger.error(String.format(Locale.ENGLISH, "%d,%d,%d,%d",
-                    ++freezeEventCounter, clock.elapsedRealtime(),
-                    freezeDuration, playbackPosition));
+                    ++freezeEventCounter, freezeStartTime,
+                    playbackPosition, freezeDuration));
         }
     }
 }


### PR DESCRIPTION
Bandwidth is now recorded at most every 16ms.
The starting time of the freeze event is recorded instead of the end time.
The order of the elements in the freeze events records has changed from: id, wall clock time, duration, video time to: id, wall clock time, video time, duration  for consistency with the head motion tracking